### PR TITLE
TCP stream overlapped feature

### DIFF
--- a/ui/qt/sctp_all_assocs_dialog.ui
+++ b/ui/qt/sctp_all_assocs_dialog.ui
@@ -393,7 +393,7 @@
     <string>Switch to the Window Scaling graph</string>
    </property>
    <property name="shortcut">
-    <string>5</string>
+    <string>6</string>
    </property>
   </action>
   <action name="actionTcptrace">
@@ -405,6 +405,17 @@
    </property>
    <property name="shortcut">
     <string>4</string>
+   </property>
+  </action>
+  <action name="actionTcpOverlapped">
+   <property name="text">
+    <string>Time / Sequence (overlapped)</string>
+   </property>
+   <property name="toolTip">
+    <string>Switch to the tcpoverlapped-style Time / Sequence graph</string>
+   </property>
+   <property name="shortcut">
+    <string>5</string>
    </property>
   </action>
  </widget>

--- a/ui/qt/tcp_stream_dialog.h
+++ b/ui/qt/tcp_stream_dialog.h
@@ -116,6 +116,15 @@ private:
     friend class GraphUpdater;
     GraphUpdater graph_updater_;
 
+    class OverlappedGraph {
+    public:
+        OverlappedGraph() { graph = nullptr; ts_offset = 0.0; }
+        QCPGraph *graph;
+        double ts_offset;
+    };
+    QVector<OverlappedGraph *> overlapped_graph_vect_;
+    void clearOverlappedGraphs(OverlappedGraph *o_graph, QCustomPlot *sp);
+
     int num_dsegs_;
     int num_acks_;
     int num_sack_ranges_;
@@ -133,6 +142,7 @@ private:
     void fillStevens();
     void fillTcptrace();
     void fillThroughput();
+    void fillTcpOverlapped();
     void fillRoundTripTime();
     void fillWindowScale();
     QString streamDescription();
@@ -189,6 +199,7 @@ private slots:
     void on_actionThroughput_triggered();
     void on_actionStevens_triggered();
     void on_actionTcptrace_triggered();
+    void on_actionTcpOverlapped_triggered();
     void on_actionWindowScaling_triggered();
     void on_buttonBox_helpRequested();
 };

--- a/ui/qt/tcp_stream_dialog.ui
+++ b/ui/qt/tcp_stream_dialog.ui
@@ -593,7 +593,7 @@
     <string>Switch to the Window Scaling graph</string>
    </property>
    <property name="shortcut">
-    <string>5</string>
+    <string>6</string>
    </property>
   </action>
   <action name="actionTcptrace">
@@ -605,6 +605,17 @@
    </property>
    <property name="shortcut">
     <string>4</string>
+   </property>
+  </action>
+  <action name="actionTcpOverlapped">
+   <property name="text">
+    <string>Time / Sequence (overlapped)</string>
+   </property>
+   <property name="toolTip">
+    <string>Switch to the tcpoverlapped-style Time / Sequence graph</string>
+   </property>
+   <property name="shortcut">
+    <string>5</string>
    </property>
   </action>
   <action name="actionZoomInX">

--- a/ui/qt/wireshark_main_window.h
+++ b/ui/qt/wireshark_main_window.h
@@ -506,6 +506,7 @@ private slots:
     void openTcpStreamDialog(int graph_type);
     void on_actionStatisticsTcpStreamStevens_triggered();
     void on_actionStatisticsTcpStreamTcptrace_triggered();
+    void on_actionStatisticsTcpStreamTcpOverlapped_triggered();
     void on_actionStatisticsTcpStreamThroughput_triggered();
     void on_actionStatisticsTcpStreamRoundTripTime_triggered();
     void on_actionStatisticsTcpStreamWindowScaling_triggered();

--- a/ui/qt/wireshark_main_window.ui
+++ b/ui/qt/wireshark_main_window.ui
@@ -463,6 +463,7 @@
      </property>
      <addaction name="actionStatisticsTcpStreamStevens"/>
      <addaction name="actionStatisticsTcpStreamTcptrace"/>
+     <addaction name="actionStatisticsTcpStreamTcpOverlapped"/>
      <addaction name="actionStatisticsTcpStreamThroughput"/>
      <addaction name="actionStatisticsTcpStreamRoundTripTime"/>
      <addaction name="actionStatisticsTcpStreamWindowScaling"/>
@@ -1792,6 +1793,14 @@
    </property>
    <property name="toolTip">
     <string>TCP time sequence graph (tcptrace)</string>
+   </property>
+  </action>
+  <action name="actionStatisticsTcpStreamTcpOverlapped">
+   <property name="text">
+    <string>Time Sequence (overlapped)</string>
+   </property>
+   <property name="toolTip">
+    <string>TCP time sequence graph (overlapped)</string>
    </property>
   </action>
   <action name="actionSCTPAnalyseThisAssociation">

--- a/ui/qt/wireshark_main_window_slots.cpp
+++ b/ui/qt/wireshark_main_window_slots.cpp
@@ -1323,6 +1323,7 @@ void WiresharkMainWindow::setMenusForSelectedPacket()
     main_ui_->actionStatisticsTcpStreamRoundTripTime->setEnabled(is_tcp);
     main_ui_->actionStatisticsTcpStreamStevens->setEnabled(is_tcp);
     main_ui_->actionStatisticsTcpStreamTcptrace->setEnabled(is_tcp);
+    main_ui_->actionStatisticsTcpStreamTcpOverlapped->setEnabled(is_tcp);
     main_ui_->actionStatisticsTcpStreamThroughput->setEnabled(is_tcp);
     main_ui_->actionStatisticsTcpStreamWindowScaling->setEnabled(is_tcp);
 
@@ -3308,6 +3309,11 @@ void WiresharkMainWindow::on_actionStatisticsTcpStreamStevens_triggered()
 void WiresharkMainWindow::on_actionStatisticsTcpStreamTcptrace_triggered()
 {
     openTcpStreamDialog(GRAPH_TSEQ_TCPTRACE);
+}
+
+void WiresharkMainWindow::on_actionStatisticsTcpStreamTcpOverlapped_triggered()
+{
+    openTcpStreamDialog(GRAPH_TSEQ_TCPOVERLAPPED);
 }
 
 void WiresharkMainWindow::on_actionStatisticsTcpStreamThroughput_triggered()

--- a/ui/tap-tcp-stream.h
+++ b/ui/tap-tcp-stream.h
@@ -21,6 +21,7 @@ extern "C" {
 typedef enum tcp_graph_type_ {
     GRAPH_TSEQ_STEVENS,
     GRAPH_TSEQ_TCPTRACE,
+    GRAPH_TSEQ_TCPOVERLAPPED,
     GRAPH_THROUGHPUT,
     GRAPH_RTT,
     GRAPH_WSCALE,


### PR DESCRIPTION
Create at TCP stream report that overlaps TCP rounds, i.e. bursts until PUSH flag is seen.

<img width="1151" alt="Screenshot 2023-08-10 at 12 08 15 PM" src="https://github.com/appneta/wireshark/assets/1899327/da3337b0-229e-4176-98bf-32bc3cbdd6f1">
